### PR TITLE
Ensure cost amounts returned by createFocusLine are strictly positive

### DIFF
--- a/src/sampleData/createSampleData.ts
+++ b/src/sampleData/createSampleData.ts
@@ -73,7 +73,10 @@ export function createFocusLine(year: number, month: number, day: number, hour: 
   const consumedQuantity = Math.floor(Math.random() * (max - min + 1)) + min;
 
   // 🎯 5️⃣ Calculate Costs
-  const billedCost = bigDecimal.multiply(consumedQuantity, sku.ListUnitPrice);
+  let billedCost = bigDecimal.multiply(consumedQuantity, sku.ListUnitPrice);
+  if (bigDecimal.compareTo(billedCost, "0") < 0) {
+    billedCost = "0";
+  }
   const effectiveCost = billedCost; // No discounts for now
   const listCost = billedCost; // Same as billed cost for now
   const contractedCost = 0; // Placeholder


### PR DESCRIPTION
I am unsure if this is an acceptable fix, I was hesitant to touch the mock object in skus.ts.

For what is worth all tests still pass.
![Screenshot 2025-04-02 at 13 18 42](https://github.com/user-attachments/assets/b7ae3b64-982a-4715-b130-61e76a777b1f)
